### PR TITLE
Remove extra index in data buffer

### DIFF
--- a/Firmware/ams5600/ams5600.ino
+++ b/Firmware/ams5600/ams5600.ino
@@ -11,8 +11,8 @@ unsigned long timestamp;
 
 // Buffer to be sent over serial that luci sensors receives and parses
 // Luci sensors is looking for the tag "+AR NCDR="
-byte buf[30] = {'+', 'A', 'R', ' ', 'N', 'C', 'D', 'R', '=', 0, 0, 0, 0, 0, 0,
-                0,   0,   0,   0,   0,   0,   0,   0,   0,   0, 0, 0, 0,0,0};
+byte buf[29] = {'+', 'A', 'R', ' ', 'N', 'C', 'D', 'R', '=', 0, 0, 0, 0, 0, 0,
+                0,   0,   0,   0,   0,   0,   0,   0,   0,   0, 0, 0, 0,0};
 
 void tcaselect(uint8_t i) {
   if (i > 7) {


### PR DESCRIPTION
Remove the extra index in the data buffer. This was causing logs to spam the luci sensors logs. 

Tested internally on a char with encoders installed and updated firmware and confirmed encoder data was still as expected and that the logs were no longer being spammed.